### PR TITLE
Remove unused job_type field from UploadAppRequest schema

### DIFF
--- a/fl_services/fl-api-base/fl_api/utils/schemas.py
+++ b/fl_services/fl-api-base/fl_api/utils/schemas.py
@@ -26,7 +26,6 @@ class UploadAppRequest(BaseModel):
     ignore_result_error: bool = False
     aggregator: str = "InTimeAccumulateWeightedAggregator"
     aggregation_weights: dict = {}
-    job_type: str = "standard"
 
 
 class ClientInfoModel(BaseModel):

--- a/fl_services/fl-api-base/tests/routers/test_application.py
+++ b/fl_services/fl-api-base/tests/routers/test_application.py
@@ -50,7 +50,6 @@ def make_upload_payload():
         "ignore_result_error": False,
         "aggregator": "InTimeAccumulateWeightedAggregator",
         "aggregation_weights": {"trustA": 0.6, "trustB": 0.4},
-        "job_type": "standard",
     }
 
 


### PR DESCRIPTION
will then need https://github.com/londonaicentre/FLIP/pull/89

## Summary

This pull request removes the `job_type` field from the `UploadAppRequest` model and updates the related test payload accordingly. This simplifies the schema by eliminating an unused or unnecessary attribute.

Schema update:

* Removed the `job_type` field from the `UploadAppRequest` model in `fl_api/utils/schemas.py`.

Test update:

* Updated the test payload in `test_application.py` to no longer include the `job_type` field.