### PR TITLE
Restrict Docker image builds

### DIFF
--- a/.github/workflows/docker_build_fl.yml
+++ b/.github/workflows/docker_build_fl.yml
@@ -15,8 +15,9 @@ name: Build and Push FL Docker Images
 on:
   push:
     branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+    paths:
+      - "fl_services/**"
+      - ".github/workflows/docker_build_fl.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Does not run in all pull_requests commits, only when triggered manually or in push to develop/main branches when changes are in specific paths