### PR TITLE
Add more information about tutorials in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,22 @@ app/
 
 For different configurations per client/server, use multiple app folders with a `meta.json` containing a `deploy_map`. See [NVFLARE documentation](https://nvflare.readthedocs.io/en/2.6/real_world_fl/job.html).
 
+## Application and tutorials
+
+Applications that will run on FLIP will take files from the `app` of choice (contained in both the `custom` and `config` folders described above), and files that are uploaded by the user to the UI. These files are customisable by the user, and examples compatible with different types of apps will be available in `tutorials`. 
+
+![image.png](./assets/fl_app_structure.png)
+
+These are the following app / tutorial compatibilities:
+
+| App | Tutorial | 
+|-----|----------|
+|`standard`|`image_segmentation/3d_spleen_segmentation`|
+|`diffusion_model`|`image_synthesis/latent_diffusion_model`|
+|`fed_opt`|`image_segmentation/3d_spleen_segmentation`|
+|`evaluation`|`image_evaluation/3d_spleen_segmentation`|
+|`standard`|`image_classification/xray_classification`|
+
 ## User Application Requirements
 
 The standard application requires:

--- a/assets/fl_app_structure.png
+++ b/assets/fl_app_structure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed9ddd430d9362d32d4328c25ae9294605dbf991b84826cd2a55b498af11785a
+size 127860


### PR DESCRIPTION
I've added more descriptions on how base-app files and tutorials interact together. 