### PR TITLE
[Feature]: Refactor upload_results_to_s3_bucket into flip core

### DIFF
--- a/flip/core/base.py
+++ b/flip/core/base.py
@@ -136,6 +136,25 @@ class FLIPBase(ABC):
             model_id (str): The model UUID
         """
 
+    @abstractmethod
+    def upload_results_to_s3(self, results_folder: Path, model_id: str) -> None:
+        """
+        Uploads results to S3 bucket.
+
+        Args:
+            results_folder (Path): The folder containing results to upload
+            model_id (str): The model UUID for which results are being uploaded
+        """
+
+    @abstractmethod
+    def cleanup(self, path: Path) -> None:
+        """
+        Cleans up local files.
+
+        Args:
+            path (Path): The path to the file or directory to clean up
+        """
+
     # ======================================================
     # Concrete Validation Methods - Shared across all implementations
     # ======================================================


### PR DESCRIPTION
This pull request introduces a refactor to the S3 upload and cleanup logic, centralizing these operations in the `flip.core.standard` module and updating dependent components and tests to use the new interface. The changes improve modularity, error handling, and test coverage for result persistence and cleanup in both production and development modes.

**Core functionality refactor:**

* Added abstract methods `upload_results_to_s3` and `cleanup` to `FLIPBase`, requiring all implementations to provide standardized S3 upload and cleanup logic.
* Implemented `upload_results_to_s3` and `cleanup` in `FLIPStandardProd` to handle zipping results, uploading to S3, and recursive cleanup, with robust logging and error handling; in `FLIPStandardDev`, these methods log actions but do not perform real uploads or deletions. [[1]](diffhunk://#diff-12bf7fe1bd1e9d65a46656257f0065b1ae74897fd5fe83cc4d40aff5b0270074R341-R400) [[2]](diffhunk://#diff-12bf7fe1bd1e9d65a46656257f0065b1ae74897fd5fe83cc4d40aff5b0270074R498-R513)

**Integration with NVFlare component:**

* Refactored `flip/nvflare/components/persist_and_cleanup.py` to delegate S3 upload and cleanup responsibilities to the `flip` object, removing direct S3 and file manipulation logic from the component. [[1]](diffhunk://#diff-6e99632ef8f48b8ea04361f449dd31f32bbedea14565a198cfe4e73ddea42ad9L149-L192) [[2]](diffhunk://#diff-6e99632ef8f48b8ea04361f449dd31f32bbedea14565a198cfe4e73ddea42ad9L201-R166)
* Removed unused imports and simplified workspace directory handling in the NVFlare component. [[1]](diffhunk://#diff-6e99632ef8f48b8ea04361f449dd31f32bbedea14565a198cfe4e73ddea42ad9L16-L19) [[2]](diffhunk://#diff-6e99632ef8f48b8ea04361f449dd31f32bbedea14565a198cfe4e73ddea42ad9L115-R113)

**Testing enhancements:**

* Added comprehensive unit tests for the new `upload_results_to_s3` and `cleanup` methods in both production and dev modes, including error scenarios and path validation.
* Updated NVFlare component tests to reflect the new interface and remove obsolete workspace mocks. [[1]](diffhunk://#diff-7855f109089cdacc1f70695e185a6032be3ff68124f069ec5d77be4248501986L101-L106) [[2]](diffhunk://#diff-7855f109089cdacc1f70695e185a6032be3ff68124f069ec5d77be4248501986R122-L139)
* Improved test setup and mocking for invalid persistor scenarios.
* Minor test utility improvements for clarity and robustness.

These changes make result persistence and cleanup more modular, testable, and robust across different deployment modes.