### PR TITLE
[Bug]: Prevent FL client calling central hub via flip package

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -28,10 +28,6 @@ IMAGES_DIR=/path/to/images
 # For fl-server (Central Hub): authenticates with flip-api via INTERNAL_SERVICE_KEY_HEADER
 INTERNAL_SERVICE_KEY_HEADER=x-internal-service-key
 INTERNAL_SERVICE_KEY=your-internal-service-key-here
-# For fl-client (trust side): authenticates with flip-api via PRIVATE_API_KEY_HEADER
-PRIVATE_API_KEY_HEADER=x-api-key
-PRIVATE_API_KEY=your-secret-api-key-here
-
 # Network and Storage Configuration
 NET_ID=your-network-id
 UPLOADED_FEDERATED_DATA_BUCKET=s3://your-bucket-name

--- a/.env.production.template
+++ b/.env.production.template
@@ -25,6 +25,10 @@ IMAGING_API_URL=https://your-imaging-api.example.com
 IMAGES_DIR=/path/to/images
 
 # API Authentication
+# For fl-server (Central Hub): authenticates with flip-api via INTERNAL_SERVICE_KEY_HEADER
+INTERNAL_SERVICE_KEY_HEADER=x-internal-service-key
+INTERNAL_SERVICE_KEY=your-internal-service-key-here
+# For fl-client (trust side): authenticates with flip-api via PRIVATE_API_KEY_HEADER
 PRIVATE_API_KEY_HEADER=x-api-key
 PRIVATE_API_KEY=your-secret-api-key-here
 

--- a/.env.test
+++ b/.env.test
@@ -26,7 +26,5 @@ CENTRAL_HUB_API_URL=https://hub.example.com
 DATA_ACCESS_API_URL=https://data.example.com
 IMAGING_API_URL=https://imaging.example.com
 IMAGES_DIR=/images
-PRIVATE_API_KEY_HEADER=x-api-key
-PRIVATE_API_KEY=test-key
 NET_ID=net-1
 UPLOADED_FEDERATED_DATA_BUCKET=s3://test-bucket

--- a/flip/constants/flip_constants.py
+++ b/flip/constants/flip_constants.py
@@ -47,17 +47,27 @@ class DevSettings(_Common):
 class ProdSettings(_Common):
     """Production environment configuration.
 
-    Used when LOCAL_DEV=false. Requires API URLs and credentials.
+    Used when LOCAL_DEV=false. Settings are grouped by which FL role uses them:
+    - **Server-only** (fl-server on Central Hub): CENTRAL_HUB_API_URL, INTERNAL_SERVICE_KEY*
+    - **Client-only** (fl-client on trust side): DATA_ACCESS_API_URL, IMAGING_API_URL, PRIVATE_API_KEY*
+    - **Shared**: IMAGES_DIR, NET_ID, UPLOADED_FEDERATED_DATA_BUCKET
     """
 
     LOCAL_DEV: bool = False
 
+    # -- Server-only: fl-server on Central Hub calls flip-api using these --
     CENTRAL_HUB_API_URL: HttpUrl = "http://localhost:8000"  # type: ignore[assignment]
+    INTERNAL_SERVICE_KEY_HEADER: str = "X-Internal-Service-Key"
+    INTERNAL_SERVICE_KEY: str = ""
+
+    # -- Client-only: fl-client on trust side calls local APIs using these --
     DATA_ACCESS_API_URL: HttpUrl = "http://localhost:8001"  # type: ignore[assignment]
     IMAGING_API_URL: HttpUrl = "http://localhost:8002"  # type: ignore[assignment]
-    IMAGES_DIR: str = ""
     PRIVATE_API_KEY_HEADER: str = "X-API-Key"
     PRIVATE_API_KEY: str = ""
+
+    # -- Shared --
+    IMAGES_DIR: str = ""
     NET_ID: str = "default"
     UPLOADED_FEDERATED_DATA_BUCKET: str = "s3://default-bucket"
 

--- a/flip/constants/flip_constants.py
+++ b/flip/constants/flip_constants.py
@@ -49,7 +49,7 @@ class ProdSettings(_Common):
 
     Used when LOCAL_DEV=false. Settings are grouped by which FL role uses them:
     - **Server-only** (fl-server on Central Hub): CENTRAL_HUB_API_URL, INTERNAL_SERVICE_KEY*
-    - **Client-only** (fl-client on trust side): DATA_ACCESS_API_URL, IMAGING_API_URL, PRIVATE_API_KEY*
+    - **Client-only** (fl-client on trust side): DATA_ACCESS_API_URL, IMAGING_API_URL
     - **Shared**: IMAGES_DIR, NET_ID, UPLOADED_FEDERATED_DATA_BUCKET
     """
 
@@ -63,8 +63,6 @@ class ProdSettings(_Common):
     # -- Client-only: fl-client on trust side calls local APIs using these --
     DATA_ACCESS_API_URL: HttpUrl = "http://localhost:8001"  # type: ignore[assignment]
     IMAGING_API_URL: HttpUrl = "http://localhost:8002"  # type: ignore[assignment]
-    PRIVATE_API_KEY_HEADER: str = "X-API-Key"
-    PRIVATE_API_KEY: str = ""
 
     # -- Shared --
     IMAGES_DIR: str = ""

--- a/flip/core/standard.py
+++ b/flip/core/standard.py
@@ -42,7 +42,21 @@ from flip.utils.utils import Utils
 
 
 class FLIPStandardProd(FLIPBase):
-    """Production implementation of FLIP for standard job types."""
+    """Production implementation of FLIP for standard job types.
+
+    Method usage by FL role:
+
+    **Server-only** (fl-server on Central Hub → calls flip-api):
+        - ``update_status()`` — update model training status
+        - ``send_metrics()`` — forward per-client training/evaluation metrics
+        - ``send_handled_exception()`` — forward client exception logs
+        - ``upload_results_to_s3()`` — upload trained model to S3
+
+    **Client-only** (fl-client on trust side → calls local trust APIs):
+        - ``get_dataframe()`` — fetch cohort data from data-access-api
+        - ``get_images()`` — download images from imaging-api
+        - ``download_data_from_s3()`` — download federated data from S3
+    """
 
     def __init__(self):
         super().__init__()
@@ -231,7 +245,7 @@ class FLIPStandardProd(FLIPBase):
             )
             response = requests.put(
                 endpoint,
-                headers={FlipConstants.PRIVATE_API_KEY_HEADER: FlipConstants.PRIVATE_API_KEY},
+                headers={FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY},
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
             response.raise_for_status()
@@ -274,7 +288,7 @@ class FLIPStandardProd(FLIPBase):
             response = requests.post(
                 endpoint,
                 json=payload,
-                headers={FlipConstants.PRIVATE_API_KEY_HEADER: FlipConstants.PRIVATE_API_KEY},
+                headers={FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY},
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
             response.raise_for_status()
@@ -322,7 +336,7 @@ class FLIPStandardProd(FLIPBase):
             response = requests.post(
                 endpoint,
                 json=payload,
-                headers={FlipConstants.PRIVATE_API_KEY_HEADER: FlipConstants.PRIVATE_API_KEY},
+                headers={FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY},
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
             response.raise_for_status()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -45,7 +45,5 @@ def pytest_sessionstart(session):
     os.environ.setdefault("DATA_ACCESS_API_URL", "https://data.example.com")
     os.environ.setdefault("IMAGING_API_URL", "https://imaging.example.com")
     os.environ.setdefault("IMAGES_DIR", "/images")
-    os.environ.setdefault("PRIVATE_API_KEY_HEADER", "x-api-key")
-    os.environ.setdefault("PRIVATE_API_KEY", "test-key")
     os.environ.setdefault("NET_ID", "net-1")
     os.environ.setdefault("UPLOADED_FEDERATED_DATA_BUCKET", "s3://test-bucket")

--- a/tests/unit/constants/test_flip_constants.py
+++ b/tests/unit/constants/test_flip_constants.py
@@ -79,8 +79,6 @@ class TestProdSettings:
             "DATA_ACCESS_API_URL": "https://data-access.example.com",
             "IMAGING_API_URL": "https://imaging.example.com",
             "IMAGES_DIR": "/data/images",
-            "PRIVATE_API_KEY_HEADER": "X-API-Key",
-            "PRIVATE_API_KEY": "secret-key-123",
             "NET_ID": "net-1",
             "UPLOADED_FEDERATED_DATA_BUCKET": "s3://my-bucket",
         }

--- a/tests/unit/core/test_standard.py
+++ b/tests/unit/core/test_standard.py
@@ -282,6 +282,8 @@ class TestFLIPStandardProdUpdateStatus:
             patch("flip.core.standard.requests.put", return_value=mock_response) as mock_put,
         ):
             mock_constants.CENTRAL_HUB_API_URL = "https://hub.example.com"
+            mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
+            mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
             mock_constants.PRIVATE_API_KEY_HEADER = "x-api-key"
             mock_constants.PRIVATE_API_KEY = "test-key"
 
@@ -322,6 +324,8 @@ class TestFLIPStandardProdSendHandledException:
             patch("flip.core.standard.requests.post", return_value=mock_response) as mock_post,
         ):
             mock_constants.CENTRAL_HUB_API_URL = "https://hub.example.com"
+            mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
+            mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
             mock_constants.PRIVATE_API_KEY_HEADER = "x-api-key"
             mock_constants.PRIVATE_API_KEY = "test-key"
 

--- a/tests/unit/core/test_standard.py
+++ b/tests/unit/core/test_standard.py
@@ -284,8 +284,6 @@ class TestFLIPStandardProdUpdateStatus:
             mock_constants.CENTRAL_HUB_API_URL = "https://hub.example.com"
             mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
             mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
-            mock_constants.PRIVATE_API_KEY_HEADER = "x-api-key"
-            mock_constants.PRIVATE_API_KEY = "test-key"
 
             flip_prod.update_status(valid_model_id, ModelStatus.TRAINING_STARTED)
 
@@ -326,8 +324,6 @@ class TestFLIPStandardProdSendHandledException:
             mock_constants.CENTRAL_HUB_API_URL = "https://hub.example.com"
             mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
             mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
-            mock_constants.PRIVATE_API_KEY_HEADER = "x-api-key"
-            mock_constants.PRIVATE_API_KEY = "test-key"
 
             flip_prod.send_handled_exception("Error message", "client-1", valid_model_id)
 


### PR DESCRIPTION
This pull request updates the authentication mechanism for internal service API calls in the production FLIP codebase. The main change is replacing the previous "private API key" approach with a new "internal service key" for communications between the central hub (fl-server) and flip-api. The configuration, code, and tests have been updated accordingly, and documentation has been improved to clarify which settings are used by each FL role.

**Authentication and Configuration Updates:**

* Replaced `PRIVATE_API_KEY_HEADER` and `PRIVATE_API_KEY` with `INTERNAL_SERVICE_KEY_HEADER` and `INTERNAL_SERVICE_KEY` in production and test environment templates (`.env.production.template`, `.env.test`). [[1]](diffhunk://#diff-014f3fd3726e1d54ca22eab0839102ba65751960b01e927e61ea0ff38656eb8dL28-R30) [[2]](diffhunk://#diff-bd8c5a5839b43575d62ee4f8b0cf6688f479ddd92251d43708b17259a48997baL29-L30)
* Updated `flip_constants.py` to remove the old private API key settings and add the new internal service key settings, with clear documentation on which roles use which settings.

**Core Logic Changes:**

* Updated all internal API calls in `flip/core/standard.py` (`update_status`, `send_metrics`, `send_handled_exception`) to use the new internal service key headers instead of the private API key. [[1]](diffhunk://#diff-12bf7fe1bd1e9d65a46656257f0065b1ae74897fd5fe83cc4d40aff5b0270074L234-R248) [[2]](diffhunk://#diff-12bf7fe1bd1e9d65a46656257f0065b1ae74897fd5fe83cc4d40aff5b0270074L277-R291) [[3]](diffhunk://#diff-12bf7fe1bd1e9d65a46656257f0065b1ae74897fd5fe83cc4d40aff5b0270074L325-R339)
* Improved class-level documentation in `FLIPStandardProd` to explicitly list which methods are used by the server and client roles.

**Test and Fixture Updates:**

* Updated tests and test fixtures to use the new internal service key environment variables and mock values, removing references to the old private API key. (`tests/unit/conftest.py`, `tests/unit/constants/test_flip_constants.py`, `tests/unit/core/test_standard.py`) [[1]](diffhunk://#diff-0cae8a7ee2d37098b1ad84b543d17cfc1e8535eed5fd6abac88c668bfe354cbbL48-L49) [[2]](diffhunk://#diff-9afe362d7eb4c8295a2d0fc33472c33a16018edf2efea476c97e2c61cd3b487bL82-L83) [[3]](diffhunk://#diff-6fa937738b0b1292b0a9fe7feb57d9bee5bc1de49124b1fad69edab3a8bbaf08L285-R286) [[4]](diffhunk://#diff-6fa937738b0b1292b0a9fe7feb57d9bee5bc1de49124b1fad69edab3a8bbaf08L325-R326)