### PR TITLE
Evaluation tutorial: evaluate full cohort, drop LOCAL_ROUNDS/TEST_SPLIT

### DIFF
--- a/tutorials/image_evaluation/3d_spleen_segmentation_evaluation/app_files/config.json
+++ b/tutorials/image_evaluation/3d_spleen_segmentation_evaluation/app_files/config.json
@@ -1,9 +1,7 @@
 {
   "job_type": "evaluation",
-  "LOCAL_ROUNDS": 2,
   "LEARNING_RATE": 1e-4,
   "num_classes": 2,
-  "TEST_SPLIT": 0.25,
   "net_config": {
     "spatial_dims": 3
   },

--- a/tutorials/image_evaluation/3d_spleen_segmentation_evaluation/app_files/evaluator.py
+++ b/tutorials/image_evaluation/3d_spleen_segmentation_evaluation/app_files/evaluator.py
@@ -47,7 +47,6 @@ class FLIP_EVALUATOR(Executor):
         working_dir = Path(__file__).parent.resolve()
         with open(str(working_dir / "config.json")) as file:
             self.config = json.load(file)
-            self._test_split = self.config["TEST_SPLIT"]
             self.num_classes = self.config["num_classes"]
 
         # Setup the model
@@ -138,14 +137,11 @@ class FLIP_EVALUATOR(Executor):
 
             print(f"Added {this_accession_matches} matched image + segmentation pairs for {accession_id}.")
 
-        print(f"Found {len(datalist)} files in total.")
+        # Evaluation-only: score every matched image/label pair in this
+        # client's cohort, not a held-out fraction.
+        print(f"Found {len(datalist)} files in total — evaluating all of them.")
 
-        # split into the training and testing data
-        _, test_datalist = np.split(datalist, [int((1 - self._test_split) * len(datalist))])
-
-        print(f"Found {len(test_datalist)} files in testing.")
-
-        return test_datalist
+        return datalist
 
     def _get_json_results_from_numpy(self, metric_results):
         output_results = {}


### PR DESCRIPTION
## Summary
- Remove the `TEST_SPLIT` / `np.split` data-splitting step from the 3D spleen evaluation tutorial so evaluation-only jobs score every matched image/label pair per client.
- Drop the unused `LOCAL_ROUNDS` knob from the tutorial's `config.json`.

## Test plan
- [ ] `make unit-test` passes.
- [ ] Run the 3D spleen evaluation tutorial end-to-end and confirm the per-client datalist is no longer truncated to 25 %.