### PR TITLE
Add Flower server-side helpers for metrics and exception forwarding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ flip-fl-base/
 │   │   ├── controllers/        # Workflow controllers (ScatterAndGather, CrossSiteModelEval)
 │   │   ├── executors/          # RUN_TRAINER, RUN_VALIDATOR, RUN_EVALUATOR
 │   │   └── components/         # Event handlers, persistors, privacy filters, locators
+│   ├── flower/                 # Flower server-side helpers (metrics/exception forwarding)
 │   └── utils/                  # General utilities, model weight helpers
 ├── src/                        # Application job type templates
 │   ├── standard/app/           # Standard federated training (FedAvg)

--- a/README.md
+++ b/README.md
@@ -81,14 +81,21 @@ flip/
 ├── core/         # FLIPBase, FLIPStandardProd/Dev implementations, FLIP() factory
 ├── constants/    # FlipConstants (pydantic-settings), enums, PTConstants
 ├── utils/        # General utilities: Utils, model weight helpers
-└── nvflare/      # NVFLARE-specific logic and components
-    ├── executors/    # RUN_TRAINER, RUN_VALIDATOR, RUN_EVALUATOR wrappers
-    ├── controllers/  # Workflow controllers (ScatterAndGather, CrossSiteModelEval, …)
-    └── components/   # Event handlers, persistors, privacy filters, locators, …
+├── nvflare/      # NVFLARE-specific logic and components
+│   ├── executors/    # RUN_TRAINER, RUN_VALIDATOR, RUN_EVALUATOR wrappers
+│   ├── controllers/  # Workflow controllers (ScatterAndGather, CrossSiteModelEval, …)
+│   └── components/   # Event handlers, persistors, privacy filters, locators, …
+└── flower/       # Flower-specific server-side helpers
+    └── metrics.py    # handle_client_metrics / handle_client_exception
 ```
 
 The `FLIP()` factory selects `FLIPStandardDev` (local CSV/filesystem) or `FLIPStandardProd` (FLIP platform APIs) based
 on the `LOCAL_DEV` environment variable.
+
+The `flip.flower` sub-package is intended **only for fl-server code**. Its helpers forward per-client metrics and
+crashed-reply exceptions — extracted from Flower reply Messages in `Strategy.aggregate_train` /
+`aggregate_evaluate` — to the Central Hub. fl-client containers must never import it and must never hold the
+`INTERNAL_SERVICE_KEY` credential. For the NVFLARE equivalent, see `flip.nvflare.metrics`.
 
 ### User Application Requirements
 

--- a/flip/flower/__init__.py
+++ b/flip/flower/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/flip/flower/metrics.py
+++ b/flip/flower/metrics.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Flower metrics utilities — mirrors flip.nvflare.metrics for the Flower framework.
+
+In Flower, clients return metrics in their reply Message via MetricRecord.
+The server-side strategy receives these in aggregate_train / aggregate_evaluate
+and should call handle_client_metrics to forward them to the Central Hub.
+
+Only the fl-server should import from this module — it forwards to the
+Central Hub using credentials that must never reach the fl-client containers.
+
+Usage (server-side, in a FedAvg strategy subclass):
+
+    from flip.flower.metrics import handle_client_metrics, handle_client_exception
+
+    def aggregate_train(self, server_round, replies):
+        for msg in replies:
+            handle_client_metrics(msg, server_round, self.model_id, self.flip)
+            handle_client_exception(msg, self.model_id, self.flip)
+        return super().aggregate_train(server_round, replies)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from flip import FLIP
+from flip.constants.flip_constants import ModelStatus
+
+if TYPE_CHECKING:
+    from flwr.common.message import Message
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["handle_client_metrics", "handle_client_exception"]
+
+# Metric keys that are bookkeeping rather than reportable metrics.
+_BOOKKEEPING_KEYS = frozenset({"num-examples", "num-iterations"})
+
+
+def handle_client_metrics(
+    msg: Message,
+    server_round: int,
+    model_id: str,
+    flip: FLIP = FLIP(),
+) -> None:
+    """Forward per-client metrics from a Flower reply Message to the Central Hub.
+
+    Extracts all numeric metrics from the client's MetricRecord and sends each
+    one to the Central Hub via flip.send_metrics. The metric label is converted
+    to uppercase to match the FLIP convention (e.g. "train_loss" -> "TRAIN_LOSS").
+
+    Per-epoch metric keys following the "<label>.round_<N>" pattern are split so
+    each data point is recorded against its own round number, letting the Hub
+    plot intra-round progress (e.g. "train_loss.round_5" -> label="TRAIN_LOSS",
+    round=5).
+
+    Only the fl-server should call this function — fl-clients must not hold
+    the credentials needed to reach the Central Hub.
+
+    Args:
+        msg: A Flower reply Message from a client. Expected to contain a
+            "metrics" MetricRecord and optionally a "config" ConfigRecord
+            with a "site" key identifying the client.
+        server_round: The current server round number, used as the default
+            x-axis value for any metric that does not embed its own round.
+        model_id: The FLIP model ID. Validated by the underlying ``flip``
+            implementation when it reaches the Central Hub; the handler
+            itself is tolerant so LOCAL_DEV runs with placeholder ids work.
+        flip: The FLIP instance used to reach the Central Hub.
+    """
+    if msg.has_error():
+        return
+
+    metrics = msg.content.get("metrics")
+    if not metrics:
+        return
+
+    site_name = _resolve_site_name(msg)
+
+    for label, value in dict(metrics).items():
+        if label in _BOOKKEEPING_KEYS or not isinstance(value, (int, float)):
+            continue
+
+        metric_label, metric_round = _parse_metric_key(label, server_round)
+
+        try:
+            flip.send_metrics(
+                client_name=site_name,
+                model_id=model_id,
+                label=metric_label.upper(),
+                value=float(value),
+                round=metric_round,
+            )
+            logger.info(
+                "Forwarded metric %s=%.4f for client %s (round %d)",
+                metric_label,
+                value,
+                site_name,
+                metric_round,
+            )
+        except Exception:
+            # Never let one bad metric break the aggregation loop; the hub
+            # client already logs its own HTTP failures, but guard here so an
+            # unexpected error in one iteration doesn't drop the remaining
+            # metrics for other clients in the same round.
+            logger.exception("Failed to forward metric %s for client %s", label, site_name)
+
+
+def handle_client_exception(
+    msg: Message,
+    model_id: str,
+    flip: FLIP = FLIP(),
+) -> None:
+    """Forward a crashed-client reply to the Central Hub and mark the run ERROR.
+
+    When a Flower client raises, the reply Message arrives with ``has_error()``
+    set. This helper both forwards the error string (so the Hub can display it
+    alongside the model run) and transitions the run status to ``ERROR`` —
+    without the latter, a crashed client would leave the Hub showing a
+    still-running run indefinitely.
+
+    Only the fl-server should call this function — fl-clients must not hold
+    the credentials needed to reach the Central Hub.
+
+    Args:
+        msg: A Flower reply Message from a client.
+        model_id: The FLIP model ID. Validated by the underlying ``flip``
+            implementation when it reaches the Central Hub.
+        flip: The FLIP instance used to reach the Central Hub.
+    """
+    if not msg.has_error():
+        return
+
+    site_name = _resolve_site_name(msg)
+    error_msg = str(msg.error) if msg.error else "Unknown client error"
+
+    try:
+        flip.send_handled_exception(
+            formatted_exception=error_msg,
+            client_name=site_name,
+            model_id=model_id,
+        )
+        logger.warning("Forwarded client exception for %s: %s", site_name, error_msg)
+    except Exception:
+        logger.exception("Failed to forward client exception for %s", site_name)
+
+    try:
+        flip.update_status(model_id, ModelStatus.ERROR)
+    except Exception:
+        logger.exception("Failed to transition model %s to ERROR status", model_id)
+
+
+def _resolve_site_name(msg: Message) -> str:
+    """Return the client's site name, falling back to the source node id.
+
+    Accepts either ``"site"`` (standard tutorial convention) or
+    ``"client_name"`` (used by the evaluation tutorial) from the config record
+    so downstream apps can pick either key.
+
+    Tolerates content-less messages — Flower raises ``ValueError`` when
+    ``msg.content`` is accessed on an errored reply, and the exception
+    handler legitimately encounters that case.
+    """
+    try:
+        config = msg.content.get("config")
+    except (ValueError, AttributeError):
+        config = None
+    if config:
+        for key in ("site", "client_name"):
+            if key in config:
+                return config[key]
+    return f"unknown_{msg.metadata.src_node_id}"
+
+
+def _parse_metric_key(label: str, default_round: int) -> tuple[str, int]:
+    """Split a metric key of the form ``<label>.round_<N>`` into (label, N).
+
+    If the suffix is absent or the round component isn't an int, returns
+    the original label and ``default_round``.
+    """
+    if ".round_" not in label:
+        return label, default_round
+
+    metric_label, round_str = label.rsplit(".round_", 1)
+    try:
+        return metric_label, int(round_str)
+    except ValueError:
+        return label, default_round

--- a/tests/unit/flower/__init__.py
+++ b/tests/unit/flower/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tests/unit/flower/test_metrics.py
+++ b/tests/unit/flower/test_metrics.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for flip.flower.metrics module.
+
+The flwr package is not a runtime dependency of flip-utils; the module under
+test only references Flower types behind a ``TYPE_CHECKING`` guard. These tests
+therefore use plain ``Mock`` stand-ins for Flower ``Message`` objects rather
+than importing ``flwr``.
+"""
+
+from unittest.mock import Mock
+
+from flip.constants.flip_constants import ModelStatus
+from flip.flower.metrics import handle_client_exception, handle_client_metrics
+
+VALID_MODEL_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+def _build_message(
+    metrics: dict | None = None,
+    site: str | None = None,
+    client_name: str | None = None,
+    has_error: bool = False,
+    error: object | None = None,
+    src_node_id: int = 42,
+) -> Mock:
+    """Build a minimal stand-in for a Flower reply Message.
+
+    The production module only touches ``has_error()``, ``error``,
+    ``content.get(...)``, and ``metadata.src_node_id`` — everything else on the
+    real Message class is irrelevant to this test surface.
+    """
+    content: dict[str, object] = {}
+    if metrics is not None:
+        content["metrics"] = metrics
+    config: dict[str, str] = {}
+    if site is not None:
+        config["site"] = site
+    if client_name is not None:
+        config["client_name"] = client_name
+    if config:
+        content["config"] = config
+
+    msg = Mock()
+    msg.has_error.return_value = has_error
+    msg.error = error
+    msg.content.get.side_effect = content.get
+    msg.metadata.src_node_id = src_node_id
+    return msg
+
+
+class TestHandleClientMetrics:
+    def test_errored_message_is_noop(self):
+        msg = _build_message(metrics={"loss": 0.5}, site="Trust_1", has_error=True)
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_metrics.assert_not_called()
+
+    def test_missing_metrics_is_noop(self):
+        msg = _build_message(metrics=None, site="Trust_1")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_metrics.assert_not_called()
+
+    def test_empty_metrics_is_noop(self):
+        msg = _build_message(metrics={}, site="Trust_1")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_metrics.assert_not_called()
+
+    def test_forwards_each_numeric_metric_uppercased(self):
+        msg = _build_message(metrics={"train_loss": 0.5, "val_dice": 0.8}, site="Trust_1")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=3, model_id=VALID_MODEL_ID, flip=flip)
+
+        assert flip.send_metrics.call_count == 2
+        flip.send_metrics.assert_any_call(
+            client_name="Trust_1",
+            model_id=VALID_MODEL_ID,
+            label="TRAIN_LOSS",
+            value=0.5,
+            round=3,
+        )
+        flip.send_metrics.assert_any_call(
+            client_name="Trust_1",
+            model_id=VALID_MODEL_ID,
+            label="VAL_DICE",
+            value=0.8,
+            round=3,
+        )
+
+    def test_skips_bookkeeping_keys(self):
+        msg = _build_message(
+            metrics={"num-examples": 1024, "num-iterations": 50, "loss": 0.1},
+            site="Trust_1",
+        )
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        assert flip.send_metrics.call_count == 1
+        (_, kwargs), = flip.send_metrics.call_args_list
+        assert kwargs["label"] == "LOSS"
+
+    def test_skips_non_numeric_metrics(self):
+        msg = _build_message(metrics={"note": "skip me", "loss": 0.1}, site="Trust_1")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        assert flip.send_metrics.call_count == 1
+        (_, kwargs), = flip.send_metrics.call_args_list
+        assert kwargs["label"] == "LOSS"
+
+    def test_parses_per_epoch_round_suffix(self):
+        msg = _build_message(metrics={"train_loss.round_5": 0.42}, site="Trust_1")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=99, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_metrics.assert_called_once_with(
+            client_name="Trust_1",
+            model_id=VALID_MODEL_ID,
+            label="TRAIN_LOSS",
+            value=0.42,
+            round=5,
+        )
+
+    def test_malformed_round_suffix_falls_back_to_server_round(self):
+        msg = _build_message(metrics={"train_loss.round_notanint": 0.42}, site="Trust_1")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=7, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_metrics.assert_called_once_with(
+            client_name="Trust_1",
+            model_id=VALID_MODEL_ID,
+            label="TRAIN_LOSS.ROUND_NOTANINT",
+            value=0.42,
+            round=7,
+        )
+
+    def test_falls_back_to_src_node_id_when_site_missing(self):
+        msg = _build_message(metrics={"loss": 0.1}, site=None, src_node_id=7)
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        (_, kwargs), = flip.send_metrics.call_args_list
+        assert kwargs["client_name"] == "unknown_7"
+
+    def test_accepts_client_name_config_key_as_site_fallback(self):
+        msg = _build_message(metrics={"loss": 0.1}, client_name="Trust_5")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        (_, kwargs), = flip.send_metrics.call_args_list
+        assert kwargs["client_name"] == "Trust_5"
+
+    def test_site_takes_precedence_over_client_name(self):
+        msg = _build_message(metrics={"loss": 0.1}, site="Trust_1", client_name="Trust_5")
+        flip = Mock()
+
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        (_, kwargs), = flip.send_metrics.call_args_list
+        assert kwargs["client_name"] == "Trust_1"
+
+    def test_hub_exception_does_not_break_loop(self):
+        msg = _build_message(metrics={"a": 0.1, "b": 0.2, "c": 0.3}, site="Trust_1")
+        flip = Mock()
+        flip.send_metrics.side_effect = [RuntimeError("boom"), None, None]
+
+        # Must not raise
+        handle_client_metrics(msg, server_round=1, model_id=VALID_MODEL_ID, flip=flip)
+
+        assert flip.send_metrics.call_count == 3
+
+
+class TestHandleClientException:
+    def test_no_error_is_noop(self):
+        msg = _build_message(has_error=False)
+        flip = Mock()
+
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_handled_exception.assert_not_called()
+        flip.update_status.assert_not_called()
+
+    def test_forwards_error_string(self):
+        msg = _build_message(has_error=True, error=RuntimeError("training failed"), site="Trust_2")
+        flip = Mock()
+
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_handled_exception.assert_called_once_with(
+            formatted_exception="training failed",
+            client_name="Trust_2",
+            model_id=VALID_MODEL_ID,
+        )
+
+    def test_transitions_status_to_error_on_crash(self):
+        msg = _build_message(has_error=True, error=RuntimeError("boom"), site="Trust_1")
+        flip = Mock()
+
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.update_status.assert_called_once_with(VALID_MODEL_ID, ModelStatus.ERROR)
+
+    def test_default_error_string_when_error_missing(self):
+        msg = _build_message(has_error=True, error=None, site="Trust_2")
+        flip = Mock()
+
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_handled_exception.assert_called_once_with(
+            formatted_exception="Unknown client error",
+            client_name="Trust_2",
+            model_id=VALID_MODEL_ID,
+        )
+        flip.update_status.assert_called_once_with(VALID_MODEL_ID, ModelStatus.ERROR)
+
+    def test_falls_back_to_src_node_id_when_site_missing(self):
+        msg = _build_message(has_error=True, error=RuntimeError("x"), site=None, src_node_id=11)
+        flip = Mock()
+
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        (_, kwargs), = flip.send_handled_exception.call_args_list
+        assert kwargs["client_name"] == "unknown_11"
+
+    def test_hub_exception_is_swallowed(self):
+        msg = _build_message(has_error=True, error=RuntimeError("x"), site="Trust_1")
+        flip = Mock()
+        flip.send_handled_exception.side_effect = RuntimeError("hub down")
+
+        # Must not raise
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.send_handled_exception.assert_called_once()
+        # Status transition still attempted even if the exception forward failed.
+        flip.update_status.assert_called_once_with(VALID_MODEL_ID, ModelStatus.ERROR)
+
+    def test_update_status_failure_does_not_propagate(self):
+        msg = _build_message(has_error=True, error=RuntimeError("x"), site="Trust_1")
+        flip = Mock()
+        flip.update_status.side_effect = RuntimeError("hub down")
+
+        # Must not raise — the log forward already happened; the status update failure
+        # is logged but not propagated so other crashed replies can still be processed.
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        flip.update_status.assert_called_once_with(VALID_MODEL_ID, ModelStatus.ERROR)
+
+    def test_content_access_value_error_on_errored_reply(self):
+        # Flower raises ValueError on msg.content when a reply carries only an error;
+        # the handler must still resolve a site name and transition status.
+        msg = Mock()
+        msg.has_error.return_value = True
+        msg.error = RuntimeError("boom")
+        type(msg).content = property(lambda self: (_ for _ in ()).throw(ValueError("no content")))
+        msg.metadata.src_node_id = 99
+        flip = Mock()
+
+        handle_client_exception(msg, model_id=VALID_MODEL_ID, flip=flip)
+
+        (_, kwargs), = flip.send_handled_exception.call_args_list
+        assert kwargs["client_name"] == "unknown_99"
+        flip.update_status.assert_called_once_with(VALID_MODEL_ID, ModelStatus.ERROR)


### PR DESCRIPTION
FL clients can't send metrics directly to Central Hub, so I've needed to create these handling functions to send first to FL server, then the FL server will send the metrics, exceptions, update the model status, etc.

## Summary
- New module `flip.flower.metrics` exposing `handle_client_metrics` and `handle_client_exception` — the Flower equivalent of the existing NVFLARE hub-forwarding surface.
- Metrics handler forwards each numeric value in a client's `MetricRecord` to the Central Hub, uppercases the label, supports a `"<label>.round_<N>"` suffix for per-epoch plots, skips bookkeeping keys (`num-examples`, `num-iterations`), and never lets one bad metric break the aggregation loop.
- Exception handler forwards the client error string and transitions the run status to `ERROR` so a crashed client doesn't leave the Hub showing a still-running run indefinitely.
- Designed for `fl-server` only — it's the only side holding Central Hub credentials.
- 20 unit tests using `Mock` stand-ins for `flwr.common.Message`, so `flwr` is **not** pulled into `flip-utils` as a runtime dependency (it's imported only behind `TYPE_CHECKING`).

## Test plan
- [x] `uv run pytest tests/unit/flower/ -v` — 20/20 passing locally.
- [x] `uv run ruff check flip/flower/ tests/unit/flower/` — clean.
- [ ] `make unit-test` in CI.