### PR TITLE
Add net-1 NVFLARE provisioning config for production

### DIFF
--- a/net-1_project_prod.yml
+++ b/net-1_project_prod.yml
@@ -1,0 +1,93 @@
+# Copyright (c) 2026 Guy's and St Thomas' NHS Foundation Trust & King's College London
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+api_version: 3
+name: net-1
+description: NVIDIA FLARE project yaml file for FLIP net-1 (production environment)
+
+participants:
+  # Change the name of the server (server1) to the Fully Qualified Domain Name
+  # (FQDN) of the server, for example: server1.example.com.
+  # Ensure that the FQDN is correctly mapped in the /etc/hosts file.
+  - name: fl.app.flip.aicentre.co.uk
+    type: server
+    org: AICentre
+    fed_learn_port: 8002
+    host_names: [fl.app.flip.aicentre.co.uk, fl-server-net-1]
+    default_host: fl.app.flip.aicentre.co.uk
+#    docker_comm_port: 8005
+  - name: Trust_1
+    type: client
+    org: AICentre
+    connect_to:
+      host: fl.app.flip.aicentre.co.uk
+    # Specifying listening_host will enable the creation of one pair of
+    # certificate/private key for this client, allowing the client to function
+    # as a server for 3rd-party integration.
+    # The value must be a hostname that the external trainer can reach via the network.
+    # listening_host: site-1-lh
+#    docker_comm_port: 8006
+    enable_byoc: true
+    resource:
+      num_of_gpus: 1
+      mem_per_gpu_in_GiB: 16
+  - name: Trust_2
+    type: client
+    org: AICentre
+    connect_to:
+      host: fl.app.flip.aicentre.co.uk
+    enable_byoc: true
+    resource:
+      num_of_gpus: 1
+      mem_per_gpu_in_GiB: 16
+  - name: admin@nvidia.com
+    type: admin
+    org: AICentre
+    role: project_admin
+    connect_to:
+      host: fl-server-net-1
+
+# The same methods in all builders are called in their order defined in builders section
+builders:
+  - path: nvflare.lighter.impl.workspace.WorkspaceBuilder
+    args:
+      template_file:
+        - master_template.yml
+        - aws_template.yml
+        - azure_template.yml
+  - path: nvflare.lighter.impl.static_file.StaticFileBuilder
+    args:
+      # config_folder can be set to inform NVIDIA FLARE where to get configuration
+      config_folder: config
+
+      # scheme for communication driver (currently supporting the default, grpc, only).
+      # scheme: grpc
+
+      # app_validator is used to verify if uploaded app has proper structures
+      # if not set, no app_validator is included in fed_server.json
+      # app_validator: PATH_TO_YOUR_OWN_APP_VALIDATOR
+
+      # when docker_image is set to a docker image name, docker.sh will be generated on server/client/admin
+      # docker_image:
+
+      # download_job_url is set to http://download.server.com/ as default in fed_server.json.  You can override this
+      # to different url.
+      # download_job_url: http://download.server.com/
+#      docker_image: localhost/nvflare:0.0.1
+#
+#  - path: nvflare.lighter.impl.docker.DockerBuilder
+#    args:
+#      docker_image: localhost/nvflare:0.0.1
+#      base_image: python:3.10
+#      requirements_file: docker_requirements.txt
+  - path: nvflare.lighter.impl.cert.CertBuilder
+  - path: nvflare.lighter.impl.signature.SignatureBuilder


### PR DESCRIPTION
## Summary
- New `net-1_project_prod.yml` — production NVFLARE provisioning config for net-1, mirroring the existing `net-1_project_stag.yml` but pointing at the production FQDN (`fl.app.flip.aicentre.co.uk`) with `Trust_1` and `Trust_2` as clients.
- No references yet in Makefile / CI; that wiring can come in a follow-up once the prod provisioning target is defined.

## Test plan
- [ ] Dry-run: `nvflare provision -p net-1_project_prod.yml` succeeds locally.
- [ ] Provisioned artefacts place the server under `fl.app.flip.aicentre.co.uk` and the clients under `Trust_1` / `Trust_2`.