### PR TITLE
Rename CENTRAL_HUB_API_URL -> FLIP_API_INTERNAL_URL (fl-server internal calls only)

### DIFF
--- a/.env.production.template
+++ b/.env.production.template
@@ -17,7 +17,11 @@ LOCAL_DEV=false
 MIN_CLIENTS=2
 
 # Production API URLs
-CENTRAL_HUB_API_URL=https://your-central-hub-api.example.com
+# FLIP_API_INTERNAL_URL is used by fl-server (on the Central Hub) to call flip-api
+# over the shared Docker network. It must NOT point at a public URL — the
+# CloudFront distribution in front of flip-api strips X-Internal-Service-Key
+# at the edge, so public-URL calls arrive unauthenticated.
+FLIP_API_INTERNAL_URL=http://flip-api:8000/api
 DATA_ACCESS_API_URL=https://your-data-access-api.example.com
 IMAGING_API_URL=https://your-imaging-api.example.com
 

--- a/.env.test
+++ b/.env.test
@@ -22,7 +22,7 @@ DEV_DATAFRAME=/data/local_dev/dev_dataframe.csv
 DEV_IMAGES_DIR=/data/local_dev/dev_images
 
 # Production API URLs for testing (used when testing prod mode)
-CENTRAL_HUB_API_URL=https://hub.example.com
+FLIP_API_INTERNAL_URL=https://hub.example.com
 DATA_ACCESS_API_URL=https://data.example.com
 IMAGING_API_URL=https://imaging.example.com
 IMAGES_DIR=/images

--- a/flip/constants/flip_constants.py
+++ b/flip/constants/flip_constants.py
@@ -48,15 +48,19 @@ class ProdSettings(_Common):
     """Production environment configuration.
 
     Used when LOCAL_DEV=false. Settings are grouped by which FL role uses them:
-    - **Server-only** (fl-server on Central Hub): CENTRAL_HUB_API_URL, INTERNAL_SERVICE_KEY*
+    - **Server-only** (fl-server on Central Hub): FLIP_API_INTERNAL_URL, INTERNAL_SERVICE_KEY*
     - **Client-only** (fl-client on trust side): DATA_ACCESS_API_URL, IMAGING_API_URL
     - **Shared**: IMAGES_DIR, NET_ID, UPLOADED_FEDERATED_DATA_BUCKET
     """
 
     LOCAL_DEV: bool = False
 
-    # -- Server-only: fl-server on Central Hub calls flip-api using these --
-    CENTRAL_HUB_API_URL: HttpUrl = "http://localhost:8000"  # type: ignore[assignment]
+    # -- Server-only: fl-server on Central Hub calls flip-api using these.
+    # FLIP_API_INTERNAL_URL must point at flip-api over the shared Docker network
+    # (e.g. http://flip-api:8000/api), never at the public CloudFront URL — the
+    # CloudFront distribution whitelists only Authorization/Content-Type/Origin
+    # and strips X-Internal-Service-Key at the edge, which would break auth.
+    FLIP_API_INTERNAL_URL: HttpUrl = "http://localhost:8000"  # type: ignore[assignment]
     INTERNAL_SERVICE_KEY_HEADER: str = "X-Internal-Service-Key"
     INTERNAL_SERVICE_KEY: str = ""
 

--- a/flip/core/standard.py
+++ b/flip/core/standard.py
@@ -236,7 +236,7 @@ class FLIPStandardProd(FLIPBase):
         if Utils.is_valid_uuid(model_id) is False:
             raise ValueError(f"Invalid model ID: {model_id}, cant update model status")
 
-        endpoint = f"{FlipConstants.CENTRAL_HUB_API_URL}/model/{model_id}/status/{new_model_status.value}"
+        endpoint = f"{FlipConstants.FLIP_API_INTERNAL_URL}/model/{model_id}/status/{new_model_status.value}"
 
         self.logger.info(f"Attempting to update model status to [{new_model_status}]")
         try:
@@ -280,7 +280,7 @@ class FLIPStandardProd(FLIPBase):
             "result": value,
         }
 
-        endpoint = f"{FlipConstants.CENTRAL_HUB_API_URL}/model/{model_id}/metrics"
+        endpoint = f"{FlipConstants.FLIP_API_INTERNAL_URL}/model/{model_id}/metrics"
 
         self.logger.info(f"Attempting to send metrics raised by {client_name}...")
 
@@ -328,7 +328,7 @@ class FLIPStandardProd(FLIPBase):
             "log": formatted_exception,
         }
 
-        endpoint = f"{FlipConstants.CENTRAL_HUB_API_URL}/model/{model_id}/logs"
+        endpoint = f"{FlipConstants.FLIP_API_INTERNAL_URL}/model/{model_id}/logs"
 
         self.logger.info(f"Attempting to send the exception raised by {client_name} to the Central Hub...")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,7 +41,7 @@ def pytest_sessionstart(session):
     os.environ.setdefault("DEV_IMAGES_DIR", "/data/local_dev/dev_images")
 
     # Set production environment variables for testing prod mode (fallback)
-    os.environ.setdefault("CENTRAL_HUB_API_URL", "https://hub.example.com")
+    os.environ.setdefault("FLIP_API_INTERNAL_URL", "https://hub.example.com")
     os.environ.setdefault("DATA_ACCESS_API_URL", "https://data.example.com")
     os.environ.setdefault("IMAGING_API_URL", "https://imaging.example.com")
     os.environ.setdefault("IMAGES_DIR", "/images")

--- a/tests/unit/constants/test_flip_constants.py
+++ b/tests/unit/constants/test_flip_constants.py
@@ -75,7 +75,7 @@ class TestProdSettings:
         """Return a dictionary of valid prod environment variables."""
         return {
             "LOCAL_DEV": "false",
-            "CENTRAL_HUB_API_URL": "https://central-hub.example.com",
+            "FLIP_API_INTERNAL_URL": "https://central-hub.example.com",
             "DATA_ACCESS_API_URL": "https://data-access.example.com",
             "IMAGING_API_URL": "https://imaging.example.com",
             "IMAGES_DIR": "/data/images",
@@ -88,21 +88,21 @@ class TestProdSettings:
         with patch.dict(os.environ, self.get_valid_prod_env(), clear=True):
             settings = ProdSettings()
             assert settings.LOCAL_DEV is False
-            assert str(settings.CENTRAL_HUB_API_URL) == "https://central-hub.example.com/"
+            assert str(settings.FLIP_API_INTERNAL_URL) == "https://central-hub.example.com/"
             assert settings.NET_ID == "net-1"
 
-    def test_prod_settings_uses_default_central_hub_url(self):
-        """ProdSettings should use default for CENTRAL_HUB_API_URL if not provided."""
+    def test_prod_settings_uses_default_flip_api_internal_url(self):
+        """ProdSettings should use default for FLIP_API_INTERNAL_URL if not provided."""
         env = self.get_valid_prod_env()
-        del env["CENTRAL_HUB_API_URL"]
+        del env["FLIP_API_INTERNAL_URL"]
         with patch.dict(os.environ, env, clear=True):
             settings = ProdSettings()
-            assert str(settings.CENTRAL_HUB_API_URL) == "http://localhost:8000/"
+            assert str(settings.FLIP_API_INTERNAL_URL) == "http://localhost:8000/"
 
     def test_prod_settings_validates_http_urls(self):
         """ProdSettings should validate HTTP URLs."""
         env = self.get_valid_prod_env()
-        env["CENTRAL_HUB_API_URL"] = "not-a-valid-url"
+        env["FLIP_API_INTERNAL_URL"] = "not-a-valid-url"
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(ValidationError):
                 ProdSettings()

--- a/tests/unit/core/test_standard.py
+++ b/tests/unit/core/test_standard.py
@@ -281,7 +281,7 @@ class TestFLIPStandardProdUpdateStatus:
             patch("flip.core.standard.FlipConstants") as mock_constants,
             patch("flip.core.standard.requests.put", return_value=mock_response) as mock_put,
         ):
-            mock_constants.CENTRAL_HUB_API_URL = "https://hub.example.com"
+            mock_constants.FLIP_API_INTERNAL_URL = "https://hub.example.com"
             mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
             mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
 
@@ -321,7 +321,7 @@ class TestFLIPStandardProdSendHandledException:
             patch("flip.core.standard.FlipConstants") as mock_constants,
             patch("flip.core.standard.requests.post", return_value=mock_response) as mock_post,
         ):
-            mock_constants.CENTRAL_HUB_API_URL = "https://hub.example.com"
+            mock_constants.FLIP_API_INTERNAL_URL = "https://hub.example.com"
             mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
             mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
 

--- a/tests/unit/core/test_standard.py
+++ b/tests/unit/core/test_standard.py
@@ -339,6 +339,52 @@ class TestFLIPStandardProdSendHandledException:
             flip_prod.send_handled_exception("Error message", "client-1", "model-123")
 
 
+class TestFLIPStandardProdSendMetrics:
+    """Test FLIPStandardProd send_metrics method."""
+
+    @pytest.fixture
+    def flip_prod(self):
+        """Create a FLIPStandardProd instance."""
+        return FLIPStandardProd()
+
+    def test_send_metrics_posts_to_flip_api_internal_url(self, flip_prod):
+        """send_metrics should POST to the internal flip-api URL with auth header + payload."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        model_id = "550e8400-e29b-41d4-a716-446655440000"
+
+        with (
+            patch("flip.core.standard.FlipConstants") as mock_constants,
+            patch("flip.core.standard.requests.post", return_value=mock_response) as mock_post,
+        ):
+            mock_constants.FLIP_API_INTERNAL_URL = "https://hub.example.com"
+            mock_constants.INTERNAL_SERVICE_KEY_HEADER = "x-internal-service-key"
+            mock_constants.INTERNAL_SERVICE_KEY = "test-internal-key"
+
+            flip_prod.send_metrics(
+                client_name="client-1",
+                model_id=model_id,
+                label="LOSS_FUNCTION",
+                value=0.42,
+                round=3,
+            )
+
+            mock_post.assert_called_once()
+            url = mock_post.call_args[0][0]
+            assert url == f"https://hub.example.com/model/{model_id}/metrics"
+            assert mock_post.call_args.kwargs["json"] == {
+                "trust": "client-1",
+                "globalRound": 3,
+                "label": "LOSS_FUNCTION",
+                "result": 0.42,
+            }
+            assert mock_post.call_args.kwargs["headers"] == {
+                "x-internal-service-key": "test-internal-key",
+            }
+
+
 class TestFLIPStandardProdUploadResultsToS3:
     """Test FLIPStandardProd upload_results_to_s3 method."""
 


### PR DESCRIPTION
## Summary
- Rename `ProdSettings.CENTRAL_HUB_API_URL` to `FLIP_API_INTERNAL_URL` so the intent ("flip-api's internal URL on the Central Hub") is spelled out where it's read.
- The FLIP library sends `X-Internal-Service-Key` on `update_status`, `send_metrics`, and `send_handled_exception`. That header is stripped by the CloudFront distribution in front of the public Central Hub URL (its origin-request policy whitelists only `Authorization/Content-Type/Origin`), so fl-server → flip-api calls that cross CloudFront arrive unauthenticated and return 401.
- The new name documents that this URL must resolve over an in-VPC, header-preserving path (docker-network DNS today; ECS Service Connect / Cloud Map / internal ALB after an eventual ECS migration), never the public CloudFront URL.
- Paired with `londonaicentre/FLIP#<FLIP-PR>` which updates compose files, env example, and deploy docs; the new `flare-fl-server:stag` image built from this branch will read `FLIP_API_INTERNAL_URL` instead of `CENTRAL_HUB_API_URL`.

## Test plan
- [x] `uv run pytest tests/unit/constants tests/unit/core` — 46 passed
- [ ] After merge + image rebuild, deploy to stag; confirm fl-server logs show successful 2xx on model-status, metrics, and exception endpoints (no more `Not authenticated: internal service key is missing.` 401s)
- [ ] Run a full FL job on stag; confirm `ModelStatus` transitions to `TRAINING_STARTED` / `RESULTS_UPLOADED` (or `ERROR`) instead of sticking at `INITIATED`
- [ ] Confirm `FLScheduler` net returns to `AVAILABLE` after run and the next queued job starts automatically