### PR TITLE
fix(flip_session): auto-reconnect on SessionClosed in _do_command

### DIFF
--- a/fl_services/fl-api-base/fl_api/utils/flip_session.py
+++ b/fl_services/fl-api-base/fl_api/utils/flip_session.py
@@ -12,7 +12,7 @@
 
 from typing import List, Optional, Union
 
-from nvflare.fuel.flare_api.api_spec import InternalError
+from nvflare.fuel.flare_api.api_spec import InternalError, SessionClosed
 from nvflare.fuel.flare_api.flare_api import Session
 
 from fl_api.utils.logger import logger
@@ -27,13 +27,25 @@ class FLIP_Session(Session):
         secure_mode: bool = False,
         debug: bool = False,
     ):
+        self._startup_path = startup_path
+        self._secure_mode = secure_mode
+        self._debug = debug
         super(FLIP_Session, self).__init__(username, startup_path, secure_mode, debug)
         self._error_buffer = None
 
+    def _reconnect(self) -> None:
+        """Re-initialise the underlying admin API and log in again after the session was closed."""
+        Session.__init__(self, self.username, self._startup_path, self._secure_mode, self._debug)
+        self.try_connect(timeout=5.0)
+
     def _do_command(self, cmd: str):
         """
-        Override the _do_command method to add error handling for session inactivity. If a session_inactive error is
-        caught, the method will attempt to reconnect and retry the command once.
+        Override the _do_command method to add error handling for session inactivity or closure.
+
+        On ``InternalError`` with "session_inactive", reconnects via ``try_connect`` and retries once.
+        On ``SessionClosed`` (e.g. idle timeout, fl-server restart, network blip), fully re-initialises
+        the admin session via ``_reconnect`` and retries once. Any exception on the retry is logged and
+        re-raised immediately — there is no further retry loop.
 
         Args:
             cmd (str): The command to be executed.
@@ -46,6 +58,14 @@ class FLIP_Session(Session):
                 self.try_connect(timeout=5.0)
                 return super()._do_command(cmd)
             raise e
+        except SessionClosed:
+            logger.warning("Session closed; attempting to reconnect and retry command.")
+            self._reconnect()
+            try:
+                return super()._do_command(cmd)
+            except Exception:
+                logger.error("Retry after reconnect failed for command: %s", cmd)
+                raise
 
     def check_server_status(self) -> ServerInfoModel:
         """

--- a/fl_services/fl-api-base/tests/utils/test_flip_session.py
+++ b/fl_services/fl-api-base/tests/utils/test_flip_session.py
@@ -15,7 +15,7 @@ from types import SimpleNamespace
 from unittest.mock import call, patch
 
 import pytest
-from nvflare.fuel.flare_api.api_spec import InternalError
+from nvflare.fuel.flare_api.api_spec import InternalError, SessionClosed
 
 from fl_api.utils.flip_session import FLIP_Session
 from fl_api.utils.schemas import ServerInfoModel, SystemInfoModel
@@ -48,6 +48,40 @@ def test_do_command_retries_once_on_session_inactive(session):
     try_connect.assert_called_once_with(timeout=5.0)
     assert parent_do_command.call_count == 2
     parent_do_command.assert_has_calls([call("CMD"), call("CMD")])
+
+
+def test_do_command_retries_once_on_session_closed(session):
+    """✅ Reconnect + retry once when parent _do_command raises SessionClosed."""
+    sentinel = {"reconnected": True}
+    with (
+        patch(
+            "nvflare.fuel.flare_api.flare_api.Session._do_command",
+            side_effect=[SessionClosed("session closed"), sentinel],
+        ) as parent_do_command,
+        patch.object(session, "_reconnect") as mock_reconnect,
+    ):
+        result = session._do_command("CMD")
+
+    assert result == sentinel
+    mock_reconnect.assert_called_once_with()
+    assert parent_do_command.call_count == 2
+    parent_do_command.assert_has_calls([call("CMD"), call("CMD")])
+
+
+def test_do_command_propagates_exception_if_retry_fails_after_reconnect(session):
+    """❌ SessionClosed propagates when the retry after reconnect also raises."""
+    with (
+        patch(
+            "nvflare.fuel.flare_api.flare_api.Session._do_command",
+            side_effect=[SessionClosed("session closed"), SessionClosed("still closed")],
+        ) as parent_do_command,
+        patch.object(session, "_reconnect") as mock_reconnect,
+    ):
+        with pytest.raises(SessionClosed, match="still closed"):
+            session._do_command("CMD")
+
+    mock_reconnect.assert_called_once_with()
+    assert parent_do_command.call_count == 2
 
 
 def test_check_server_status_returns_server_info(session):


### PR DESCRIPTION
## Failure mode

When the fl-server restarts, the network drops, or the admin connection has been truly idle for ~30 min, NVFLARE marks `api.closed = True` internally. Every subsequent call to `Session._do_command` immediately hits:

```python
if self.api.closed:
    raise SessionClosed("session closed")
```

The previous `FLIP_Session._do_command` override only handled `InternalError("session_inactive")`; `SessionClosed` fell through unhandled. Once the session died the fl-api service was permanently broken — the only recovery was a container restart. This was observed in staging.

Observed stack:
```
File "/app/fl_api/utils/flip_session.py", line 42, in _do_command
    return super()._do_command(cmd)
File ".../nvflare/fuel/flare_api/flare_api.py", line 122, in _do_command
    raise SessionClosed("session closed")
nvflare.fuel.flare_api.api_spec.SessionClosed: session closed
```

## Fix

- **Store constructor args** (`startup_path`, `secure_mode`, `debug`) as instance attributes in `__init__` so they are available for reconnection. (`username` was already stored by the upstream `Session.__init__`.)
- **Add `_reconnect()`** — calls `Session.__init__(self, ...)` to create a fresh `AdminAPI` (which initialises `api.closed = False`), then calls `self.try_connect(timeout=5.0)` to log in. This is necessary because when `api.closed` is `True`, `try_connect` itself also raises `SessionClosed` — so a plain `try_connect` call alone is not sufficient to reconnect.
- **Extend `_do_command`** — catches `SessionClosed`, logs a warning, calls `_reconnect()`, retries the command exactly **once**. Any exception on the retry is logged at `ERROR` level and re-raised immediately. No retry loop.

The existing `InternalError("session_inactive")` path is unchanged.

## Test plan

- [x] `test_do_command_retries_once_on_session_closed` — first call raises `SessionClosed`, second returns a sentinel; asserts the sentinel is returned, `_reconnect` called once, `super()._do_command` called twice.
- [x] `test_do_command_propagates_exception_if_retry_fails_after_reconnect` — both calls raise `SessionClosed`; asserts the second exception propagates, `_reconnect` called once.
- [x] All 59 existing tests continue to pass (`make local_test` — ruff + mypy + pytest).
- [ ] Manual: live reconnect after fl-server restart cannot be exercised in CI (requires a running NVFLARE stack).

## Open questions

None.