### PR TITLE
feat(flip): forward TRUST_INTERNAL_SERVICE_KEY on trust-internal calls

### DIFF
--- a/flip/__init__.py
+++ b/flip/__init__.py
@@ -36,4 +36,4 @@ from flip.core.factory import FLIP
 
 __all__ = ["FLIP", "FLIPBase"]
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/flip/constants/flip_constants.py
+++ b/flip/constants/flip_constants.py
@@ -49,7 +49,8 @@ class ProdSettings(_Common):
 
     Used when LOCAL_DEV=false. Settings are grouped by which FL role uses them:
     - **Server-only** (fl-server on Central Hub): FLIP_API_INTERNAL_URL, INTERNAL_SERVICE_KEY*
-    - **Client-only** (fl-client on trust side): DATA_ACCESS_API_URL, IMAGING_API_URL
+    - **Client-only** (fl-client on trust side): DATA_ACCESS_API_URL, IMAGING_API_URL,
+      TRUST_INTERNAL_SERVICE_KEY*
     - **Shared**: IMAGES_DIR, NET_ID, UPLOADED_FEDERATED_DATA_BUCKET
     """
 
@@ -67,6 +68,14 @@ class ProdSettings(_Common):
     # -- Client-only: fl-client on trust side calls local APIs using these --
     DATA_ACCESS_API_URL: HttpUrl = "http://localhost:8001"  # type: ignore[assignment]
     IMAGING_API_URL: HttpUrl = "http://localhost:8002"  # type: ignore[assignment]
+    # Trust-internal service auth — protects imaging-api and data-access-api on the
+    # trust Docker network from unauthenticated callers. The fl-client container is
+    # injected with the per-trust plaintext key in TRUST_INTERNAL_SERVICE_KEY by the
+    # trust compose stack (see trust/compose_trust.*.flower.yml / *.nvflare.yml in
+    # the FLIP repo). The flip package forwards it on every call to imaging-api or
+    # data-access-api; user training code does not deal with the header directly.
+    TRUST_INTERNAL_SERVICE_KEY_HEADER: str = "X-Trust-Internal-Service-Key"
+    TRUST_INTERNAL_SERVICE_KEY: str = ""
 
     # -- Shared --
     IMAGES_DIR: str = ""

--- a/flip/core/standard.py
+++ b/flip/core/standard.py
@@ -55,6 +55,22 @@ def _trust_internal_headers() -> dict[str, str]:
     return {FlipConstants.TRUST_INTERNAL_SERVICE_KEY_HEADER: FlipConstants.TRUST_INTERNAL_SERVICE_KEY}
 
 
+def _hub_internal_headers() -> dict[str, str]:
+    """Return the auth header sent on every hub-internal call.
+
+    Used by fl-server on the Central Hub for outbound calls to flip-api
+    (update_status, send_metrics, send_handled_exception). The receiver
+    (flip-api) compares the value with a constant-time compare against its
+    own copy. Distinct boundary from the trust-internal key — a leak in one
+    trust never affects this hub-side path and vice versa.
+
+    Returns:
+        dict[str, str]: Single-entry dict mapping the configured header name to
+        the hub internal-service key.
+    """
+    return {FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY}
+
+
 class FLIPStandardProd(FLIPBase):
     """Production implementation of FLIP for standard job types.
 
@@ -262,7 +278,7 @@ class FLIPStandardProd(FLIPBase):
             )
             response = requests.put(
                 endpoint,
-                headers={FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY},
+                headers=_hub_internal_headers(),
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
             response.raise_for_status()
@@ -305,7 +321,7 @@ class FLIPStandardProd(FLIPBase):
             response = requests.post(
                 endpoint,
                 json=payload,
-                headers={FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY},
+                headers=_hub_internal_headers(),
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
             response.raise_for_status()
@@ -353,7 +369,7 @@ class FLIPStandardProd(FLIPBase):
             response = requests.post(
                 endpoint,
                 json=payload,
-                headers={FlipConstants.INTERNAL_SERVICE_KEY_HEADER: FlipConstants.INTERNAL_SERVICE_KEY},
+                headers=_hub_internal_headers(),
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
             response.raise_for_status()

--- a/flip/core/standard.py
+++ b/flip/core/standard.py
@@ -41,6 +41,20 @@ from flip.core.base import FLIPBase
 from flip.utils.utils import Utils
 
 
+def _trust_internal_headers() -> dict[str, str]:
+    """Return the auth header sent on every trust-internal call.
+
+    Used on outbound calls to imaging-api and data-access-api. The receiver
+    (in the FLIP repo) compares the value with a constant-time compare against
+    its own copy of the same per-trust key.
+
+    Returns:
+        dict[str, str]: Single-entry dict mapping the configured header name to
+        the trust-internal service key.
+    """
+    return {FlipConstants.TRUST_INTERNAL_SERVICE_KEY_HEADER: FlipConstants.TRUST_INTERNAL_SERVICE_KEY}
+
+
 class FLIPStandardProd(FLIPBase):
     """Production implementation of FLIP for standard job types.
 
@@ -93,6 +107,7 @@ class FLIPStandardProd(FLIPBase):
         response = requests.post(
             endpoint,
             json=payload,
+            headers=_trust_internal_headers(),
         )
 
         self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
@@ -153,6 +168,7 @@ class FLIPStandardProd(FLIPBase):
                     "assessor_type": assessor_type,
                     "resource_type": resource.value,
                 },
+                headers=_trust_internal_headers(),
             )
             self.logger.info(f"Received response status code: {response.status_code}, response text: {response.text}")
 
@@ -216,6 +232,7 @@ class FLIPStandardProd(FLIPBase):
         response = requests.put(
             endpoint,
             json=payload,
+            headers=_trust_internal_headers(),
         )
 
         response.raise_for_status()

--- a/tests/unit/core/test_standard.py
+++ b/tests/unit/core/test_standard.py
@@ -173,6 +173,8 @@ class TestFLIPStandardProdGetDataframe:
             patch("flip.core.standard.requests.post", return_value=mock_response) as mock_post,
         ):
             mock_constants.DATA_ACCESS_API_URL = "https://data.example.com"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY_HEADER = "x-trust-internal-service-key"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY = "test-trust-internal-key"
 
             df = flip_prod.get_dataframe(project_id="proj-1", query="SELECT * FROM table")
 
@@ -182,6 +184,10 @@ class TestFLIPStandardProdGetDataframe:
 
             # Check that endpoint contains the expected API URL
             assert "cohort/dataframe" in call_args[0][0]
+
+            # data-access-api requires the trust-internal service key on every /cohort
+            # route — fl-client must forward the header from its container env.
+            assert call_args.kwargs["headers"]["x-trust-internal-service-key"] == "test-trust-internal-key"
 
             # Verify result is DataFrame
             assert isinstance(df, pd.DataFrame)
@@ -210,6 +216,8 @@ class TestFLIPStandardProdGetByAccessionNumber:
         ):
             mock_constants.IMAGING_API_URL = "https://imaging.example.com"
             mock_constants.NET_ID = "net-1"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY_HEADER = "x-trust-internal-service-key"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY = "test-trust-internal-key"
 
             result = flip_prod.get_by_accession_number(
                 project_id="proj-1", accession_id="ACC001", resource_type=ResourceType.DICOM
@@ -217,6 +225,10 @@ class TestFLIPStandardProdGetByAccessionNumber:
 
             # Verify API was called
             mock_post.assert_called_once()
+            # imaging-api requires the trust-internal service key on every router except
+            # /health — fl-client must forward the header from its container env.
+            call_kwargs = mock_post.call_args.kwargs
+            assert call_kwargs["headers"]["x-trust-internal-service-key"] == "test-trust-internal-key"
             assert isinstance(result, Path)
             assert str(result) == str(tmp_path / "data")
 
@@ -244,6 +256,8 @@ class TestFLIPStandardProdAddResource:
         ):
             mock_constants.IMAGING_API_URL = "https://imaging.example.com"
             mock_constants.NET_ID = "net-1"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY_HEADER = "x-trust-internal-service-key"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY = "test-trust-internal-key"
 
             flip_prod.add_resource(
                 project_id="proj-1",
@@ -257,6 +271,9 @@ class TestFLIPStandardProdAddResource:
             mock_put.assert_called_once()
             call_args = mock_put.call_args
             assert "upload/images" in call_args[0][0]
+            # imaging-api requires the trust-internal service key on every router except
+            # /health — fl-client must forward the header from its container env.
+            assert call_args.kwargs["headers"]["x-trust-internal-service-key"] == "test-trust-internal-key"
 
 
 class TestFLIPStandardProdUpdateStatus:

--- a/tests/unit/core/test_standard.py
+++ b/tests/unit/core/test_standard.py
@@ -18,6 +18,7 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
+from requests import HTTPError
 
 from flip.constants import ModelStatus, ResourceType
 from flip.core.standard import FLIPStandardDev, FLIPStandardProd
@@ -193,6 +194,34 @@ class TestFLIPStandardProdGetDataframe:
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 1
             assert df["accession_id"].iloc[0] == "ACC001"
+
+    def test_get_dataframe_forwards_empty_key_header(self, flip_prod):
+        """Header is always sent, even when TRUST_INTERNAL_SERVICE_KEY is the default empty string.
+
+        Mirrors the receiver-side fail-closed test in FLIP: if the env var is unset, the
+        sender still emits the header (empty), so the receiver rejects with 401 rather than
+        silently bypassing auth via a missing-header code path.
+        """
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.text = "unauthorized"
+        mock_response.raise_for_status.side_effect = HTTPError("401")
+
+        with (
+            patch("flip.core.standard.FlipConstants") as mock_constants,
+            patch("flip.core.standard.requests.post", return_value=mock_response) as mock_post,
+        ):
+            mock_constants.DATA_ACCESS_API_URL = "https://data.example.com"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY_HEADER = "x-trust-internal-service-key"
+            mock_constants.TRUST_INTERNAL_SERVICE_KEY = ""
+
+            with pytest.raises(HTTPError):
+                flip_prod.get_dataframe(project_id="proj-1", query="SELECT * FROM table")
+
+            mock_post.assert_called_once()
+            headers = mock_post.call_args.kwargs["headers"]
+            assert "x-trust-internal-service-key" in headers
+            assert headers["x-trust-internal-service-key"] == ""
 
 
 class TestFLIPStandardProdGetByAccessionNumber:

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,6 @@ wheels = [
 ]
 
 [[package]]
-version = "0.1.4"
 name = "flip-utils"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

- Adds `TRUST_INTERNAL_SERVICE_KEY_HEADER` and `TRUST_INTERNAL_SERVICE_KEY` to `ProdSettings`, and forwards the header on every fl-client → imaging-api / data-access-api request from `FLIPStandardProd` (`get_dataframe`, `get_by_accession_number`, `add_resource`) via a shared `_trust_internal_headers()` helper.
- Bumps `flip-utils` 0.1.5 → 0.1.6 so dependents pin via the existing `>=0.1.3` constraint without further changes.
- Tutorials and user-uploaded `client_app.py` / `server_app.py` are unchanged — the package owns transport-level auth.

## Why now

The matching FLIP-side change ([`londonaicentre/FLIP#claude/add-imaging-api-auth-mdUUB`](https://github.com/londonaicentre/FLIP/tree/claude/add-imaging-api-auth-mdUUB), addressing P1-01 + P1-03 in the security review) makes both imaging-api and data-access-api fail-closed on every `/cohort` and non-`/health` route without `X-Trust-Internal-Service-Key`. Without this PR every `flip.get_dataframe(...)` and `flip.get_by_accession_number(...)` call from an fl-client would 401 once the FLIP images deploy.

The trust-side compose plumbing (already in the FLIP repo's `trust/compose_trust.*.flower.yml` and `*.nvflare.yml`) injects `TRUST_INTERNAL_SERVICE_KEY` and `TRUST_INTERNAL_SERVICE_KEY_HEADER` into the fl-client container env. `ProdSettings` reads them via pydantic-settings.

## Hub-side calls unchanged

`update_status`, `send_metrics`, `send_handled_exception` continue using the hub's `INTERNAL_SERVICE_KEY*`. That's a separate trust boundary (fl-server → flip-api on the Central Hub). The two keys are deliberately distinct so a leaked trust key cannot drive the hub and vice versa.

## Deploy chain

1. Merge this PR.
2. CI publishes `flip-utils==0.1.6` to PyPI on merge to `develop` / `main` (per repo convention).
3. Rebuild fl-client images in this repo (NVFLARE) and `flip-fl-base-flower` (Flower). Production Dockerfile target installs `flip-utils` fresh from PyPI under the existing `>=0.1.3` constraint, so the rebuild picks up 0.1.6 automatically — no constraint bump needed.
4. Roll the new fl-client images on every trust deployment alongside the FLIP-side imaging-api / data-access-api images, so the receiver and sender ship together.

## Test plan

- [x] `uv run ruff check flip/ tests/` — clean.
- [x] `uv run mypy flip/constants/flip_constants.py flip/core/standard.py flip/__init__.py` — clean.
- [x] `uv run pytest tests/unit/core/ tests/unit/constants/ tests/unit/test_flip_package.py` — 76 passed. Updated `test_standard.py` asserts the header is sent on each of the three trust-internal call sites.
- [ ] After merge: confirm the `flip-utils 0.1.6` release lands on PyPI before kicking off rebuilds.
- [ ] After deploy: smoke-test an fl-client → data-access-api `/cohort/dataframe` call from the trust stack and verify 200 (vs. 401 without the header).

## Out of scope

- The hub-side `INTERNAL_SERVICE_KEY*` could be renamed `HUB_INTERNAL_SERVICE_KEY*` to mirror `TRUST_INTERNAL_SERVICE_KEY*` and remove the naming asymmetry. Touches AWS Secrets Manager schema and needs a coordinated cross-repo deploy — deliberately deferred to a separate PR.
- `flip-fl-base-flower` needs no code change. Its tutorial `uv.lock` files pin `flip-utils == 0.1.4` and could be regenerated (or deleted, since they're not strictly needed for tutorials) once 0.1.6 is on PyPI.